### PR TITLE
Removed extra 0 from list

### DIFF
--- a/src/main/java/com/facebook/LinkBench/LinkStoreTarantool.java
+++ b/src/main/java/com/facebook/LinkBench/LinkStoreTarantool.java
@@ -582,6 +582,7 @@ private static class Converter {
         List nodeAsList = new ArrayList();
         nodeAsList.add(node.id);
         nodeAsList.addAll(Converter.NodeToList(node));
+        nodeAsList.remove(1);
         List res = syncOps.call(METHOD_UPDATE_NODE, nodeAsList);
         return (Boolean)((List) res.get(0)).get(0);
     }


### PR DESCRIPTION
We have to remove empty node ID from the `nodeAsList`
Because node ID added twice, first time on  the L:583 , and the second time in the `NodeToList` function.